### PR TITLE
Add issue/PR templates and CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: File a report for unexpected or incorrect behavior
+labels:
+  - bug
+---
+
+## Checklist
+
+- [ ] I updated to the latest version and the problem persists.
+- [ ] I searched the [existing GitHub issues][1] and this hasn't already been reported.
+
+## Overview
+
+<!-- Give a brief summary of the issue. -->
+
+## Example Reproduction
+
+<!--  Give a short code example that causes this problem. Don't paste the code from your project exactly as-is; instead, try to isolate the problem and provide a short code sample that still runs into the same issue. -->
+
+```cs
+// Put your code here.
+```
+
+## Behavior
+
+<!-- What did you expect to happen and how does the actual behavior differ? -->
+
+## Environment
+
+<!--
+    Provide some information about your build environment, such as:
+     - what version of the library you're using
+     - what .NET version you're using
+     - what OS you're building on
+-->
+
+[1]: https://github.com/Tiny-Home-Consulting/DataOnion/issues?q=is%3Aissue

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Request a new feature to be added to the library
+labels:
+  - enhancement
+---
+
+## Checklist
+
+- [ ] I searched the [existing GitHub issues][1] and this hasn't already been requested.
+
+## Problem
+
+<!-- What's the problem you have that this feature would solve? This is different from the exact feature itself -- describe the underlying problem that led you to request this feature. -->
+
+## Feature Request
+
+<!-- What is the feature you want to see added to the library? Code samples showing how it would be used are appreciated, but not required. The more detail you can provide, the better. -->
+
+## Value
+
+<!-- Why should it be part of this library? Explain the benefits of adding this to DataOnion. -->
+
+[1]: https://github.com/Tiny-Home-Consulting/DataOnion/issues?q=is%3Aissue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Issue Link
+
+<!--
+    Use a linking keyword and issue number. For example, this section could say:
+        Fixes #41
+    If there is no link, you may remove this section. However, larger PRs may be rejected if there is no corresponding issue.
+
+    You may also put more than one issue here, if multiple apply. These issues should be related; unrelated issues likely belong to separate PRs.
+-->
+
+Fixes #X
+
+## Overview of Changes
+
+<!-- What does this PR actually do? This section should include a brief summary of what the code changes are or why the issue was occurring, and if there is no linked issue, why you feel this change is necessary. -->
+
+### Anything you want to highlight?
+
+<!-- If you want reviewers to pay special attention to one part of your PR, mention that here. This is purely optional, especially on smaller PRs. -->
+
+## Test Plan
+
+<!-- If this PR touches the code, provide a detailed plan of how you tested your PR. The behavior should differ between your branch and master. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing Guidelines
+
+## Submitting Issues
+
+Before submitting an issue, check the [existing GitHub issues][1] to ensure it has not already been
+reported. If no issue exists, follow one of the issue templates provided. Follow the instructions
+left in the comments (delimited by `<!-- ... -->`).
+
+## Pull Requests
+
+Before submitting a PR, check the [issues][1] and [open PRs][2] to see whether it has already been
+covered. Each PR should correspond to an issue; this may not be necessary for some PRs, but we
+reserve the right to reject PRs on the basis that they were not first discussed in an issue.
+
+When you create the PR, please follow the pull request template. We will reject PRs that do not
+follow the instructions left in the comments of the template.
+
+[1]: https://github.com/Tiny-Home-Consulting/DataOnion/issues?q=is%3Aissue
+[2]: https://github.com/Tiny-Home-Consulting/DataOnion/pulls


### PR DESCRIPTION
This PR adds a PR template, issue templates, and a CONTRIBUTING.md file that are closely modeled after those used for Dependiject. There's a couple things I'm not sure about so I would appreciate any feedback. Namely:

- I left out the sections that reference documentation and automated tests, as currently this repo has none.
- The CONTRIBUTING file for Dependiject also references code style. I left this part out as I don't know if there's any specific style guide we follow or what conventions I should specify.
- I wasn't sure what to put in the environment section of the bug report template. Apple forces you to use macOS and Xcode, so for Dependiject I used a simple software-version table. C# is more open, so it's harder to make assumptions about how a project is built.