### PR TITLE
THOS-10: Pass through splitOn in Dapper Service

### DIFF
--- a/DataOnion/DataOnion.csproj
+++ b/DataOnion/DataOnion.csproj
@@ -3,7 +3,7 @@
     <Title>Data Onion</Title>
     <Description>A collection of useful wrappers around Dapper, Entity Framework and other packages to accelerate early project development.</Description>
     <PackageId>DataOnion</PackageId>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
     <Authors>Kyle Lawhorn</Authors>
     <Company>Tiny Home Consulting, LLC.</Company>
     <Copyright>Copyright (c) 2022 Tiny Home Consulting, LLC.</Copyright>

--- a/DataOnion/db/DapperService.cs
+++ b/DataOnion/db/DapperService.cs
@@ -31,14 +31,15 @@ namespace DataOnion.db
         public async Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond>(
             string query,
             Func<TFirst, TSecond, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         )
         {             
             var result = await _connection.QueryAsync<TFirst, TSecond, TFirst>(
                 query,
                 mappingFunction,
-                parameters
+                parameters,
+                splitOn: splitOn
             );
 
             return result;
@@ -47,14 +48,15 @@ namespace DataOnion.db
         public async Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird>(
             string query,
             Func<TFirst, TSecond, TThird, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         )
         {            
             var result = await _connection.QueryAsync<TFirst, TSecond, TThird, TFirst>(
                 query,
                 mappingFunction,
-                parameters
+                parameters,
+                splitOn: splitOn
             );
 
             return result;
@@ -63,14 +65,15 @@ namespace DataOnion.db
         public async Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird, TFourth>(
             string query,
             Func<TFirst, TSecond, TThird, TFourth, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         )
         {            
             var result = await _connection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFirst>(
                 query,
                 mappingFunction,
-                parameters
+                parameters,
+                splitOn: splitOn
             );
 
             return result;
@@ -79,14 +82,15 @@ namespace DataOnion.db
         public async Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird, TFourth, TFifth>(
             string query,
             Func<TFirst, TSecond, TThird, TFourth, TFifth, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         )
         {             
             var result = await _connection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TFirst>(
                 query,
                 mappingFunction,
-                parameters
+                parameters,
+                splitOn: splitOn
             );
 
             return result;
@@ -95,14 +99,15 @@ namespace DataOnion.db
         public async Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth>(
             string query,
             Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         )
         {            
             var result = await _connection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TFirst>(
                 query,
                 mappingFunction,
-                parameters
+                parameters,
+                splitOn: splitOn
             );
 
             return result;
@@ -111,14 +116,15 @@ namespace DataOnion.db
         public async Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(
             string query,
             Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         )
         {              
             var result = await _connection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TFirst>(
                 query,
                 mappingFunction,
-                parameters
+                parameters,
+                splitOn: splitOn
             );
 
             return result;

--- a/DataOnion/db/IDapperService.cs
+++ b/DataOnion/db/IDapperService.cs
@@ -13,42 +13,42 @@ namespace DataOnion.db
         Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond>(
             string query,
             Func<TFirst, TSecond, TFirst> mappingFunction,
-            string? splitOn = null, 
+            string splitOn = "Id", 
             object? parameters = null
         );
 
         Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird>(
             string query,
             Func<TFirst, TSecond, TThird, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         );
 
         Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird, TFourth>(
             string query,
             Func<TFirst, TSecond, TThird, TFourth, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         );
 
         Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird, TFourth, TFifth>(
             string query,
             Func<TFirst, TSecond, TThird, TFourth, TFifth, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         );
 
         Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth>(
             string query,
             Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         );
 
         Task<IEnumerable<TFirst>> QueryAndReturnAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh>(
             string query,
             Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TFirst> mappingFunction,
-            string? splitOn = null,
+            string splitOn = "Id",
             object? parameters = null
         );
 


### PR DESCRIPTION
## Issue Link

Fixes #9 | [Jira](https://tinyhomeconsultingllc.atlassian.net/browse/THOS-10)

Fixes #X

## Overview of Changes

This PR changes `splitOn` to be non-nullable and updates the default value to "Id" to match the default value in the dapper `QueryAsync()` method and then passes it through.

### Anything you want to highlight?

n/a

## Test Plan

- In any application that uses this library, use data onion as a project reference rather than a nuget package and verify calls that use dapper multi-mapping still behave as expected.
- You'll also want to use splitOn with a value other than "Id" to ensure that it actually gets passed through