### PR TITLE
Feature/THOS-23: Expose DB Context in IEFCoreService

### DIFF
--- a/DataOnion/db/EFCoreService.cs
+++ b/DataOnion/db/EFCoreService.cs
@@ -8,6 +8,8 @@ namespace DataOnion.db
     {
         private readonly TDbContext _context;
 
+        public TDbContext DbContext => _context;
+
         public EFCoreService(
             TDbContext context
         )

--- a/DataOnion/db/IEFCoreService.cs
+++ b/DataOnion/db/IEFCoreService.cs
@@ -9,6 +9,7 @@ namespace DataOnion.db
 
     public interface IEFCoreService<TDbContext>
     {
+        TDbContext DbContext { get; }
         // crud
         Task<TEntity> CreateAsync<TEntity>(
             TEntity entity


### PR DESCRIPTION
## Issue Link

[Jira Issue #23](https://tinyhomeconsultingllc.atlassian.net/browse/THOS-23)

Fixes #X

## Overview of Changes

This PR adds `DbContext` as a property to `IEFCoreService`, exposing the db context to the client. This allows the client to access the context, a use case would be to create a db transaction.

### Anything you want to highlight?

n/a

## Test Plan

- In a project that uses this `IEFCoreService`, the client has access to the `DbContext` property
- This was tested by performing a transaction using the `DbContext` property
```
using ApplicationContext context = _efCoreService.DbContext;
using var transaction = context.Database.BeginTransaction();
...
transaction.Commit();
```