### PR TITLE
Handle deserialization errors

### DIFF
--- a/DataOnion/DataOnion.csproj
+++ b/DataOnion/DataOnion.csproj
@@ -3,7 +3,7 @@
     <Title>Data Onion</Title>
     <Description>A collection of useful wrappers around Dapper, Entity Framework and other packages to accelerate early project development.</Description>
     <PackageId>DataOnion</PackageId>
-    <Version>0.0.6</Version>
+    <Version>0.0.7</Version>
     <Authors>Kyle Lawhorn</Authors>
     <Company>Tiny Home Consulting, LLC.</Company>
     <Copyright>Copyright (c) 2022 Tiny Home Consulting, LLC.</Copyright>


### PR DESCRIPTION
## Issue Link

https://combinedpublic.atlassian.net/browse/CPC-9053

## Overview of Changes

If the project using DataOnion calls `LogoutAsync` in parallel with `GetSessionAsync`, the Redis store can end up in an invalid state -- namely, the hash will only have an expiration value, and none of the values needed to create the auth session object. Because of the nature of the race condition, this is nearly impossible to prevent, and it's easier to detect and correct this immediately after it happens. The new try/catch block in `GetSessionAsync` is meant to do exactly this. In case this somehow happens without `GetSessionAsync` noticing, or such a key already exists in the Redis store, `LoginAsync` will also handle this. I factored out some common code to a new private function, `CreateSessionAsync`. 

## Test Plan

It was previously possible to get the Redis store in an invalid state by calling `GetSessionAsync` and `LogoutAsync` in parallel with the correct timing, though due to the nature of race conditions it wasn't consistent. This should no longer be possible.

The easiest way to test the new login code is to artificially trigger this: take an existing session and delete all information from the hash except for the expiration time. Then, try to log in again with that invalid Redis key. You should see a warning printed to the console, but login will succeed, as DataOnion will delete and re-create the invalid entry.

To use a local copy of DataOnion, clone the repo, and replace the PackageReference in the consumer's .csproj file with something like this:

```xml
    <ProjectReference Include="..\path\to\DataOnion\DataOnion.csproj">
        <PrivateAssets>All</PrivateAssets>
    </ProjectReference>
```

Note that the include path uses backslashes (<code>&bsol;</code>) rather than the more typical forward slashes (`/`) as the path separator.